### PR TITLE
change bPendingStopped as a protected member

### DIFF
--- a/Source/InfraworldRuntime/Public/Conduit.h
+++ b/Source/InfraworldRuntime/Public/Conduit.h
@@ -17,7 +17,7 @@
 
 #include "CoreMinimal.h"
 #include "HAL/PlatformTLS.h"
-#include "Queue.h"
+#include "Containers/Queue.h"
 
 /**
  * A conduit is a combination of two channel: The Request channel, and the Response channel, representing bidirectional queue.

--- a/Source/InfraworldRuntime/Public/RpcClientWorker.h
+++ b/Source/InfraworldRuntime/Public/RpcClientWorker.h
@@ -58,10 +58,10 @@ public:
 //public:
     FString URI;
     UChannelCredentials* ChannelCredentials;
-    
+
     TQueue<FRpcError>* ErrorMessageQueue;
 
-private:
+protected:
     // False by default. Being set to true when the thread is need to be shut down.
 	volatile bool bPendingStopped;
 };


### PR DESCRIPTION
This allow us to override the Run() method. 