### PR TITLE
Fixed an issue where engine would crash randomly, especially when changing scenes

### DIFF
--- a/Source/InfraworldRuntime/Public/RpcClient.h
+++ b/Source/InfraworldRuntime/Public/RpcClient.h
@@ -21,6 +21,7 @@
 
 #include "Containers/Queue.h"
 #include "Templates/SubclassOf.h"
+#include "Templates/Atomic.h"
 
 #include "RpcClientWorker.h"
 #include "ChannelCredentials.h"
@@ -129,11 +130,13 @@ protected:
     TUniquePtr<RpcClientWorker> InnerWorker;
 
 private:
+    virtual void BeginDestroy() override;
+
     /** Whether the RPC Client could send requests or not */
     bool bCanSendRequests = false;
 
     /** A thread, where RPC client worker will reside */
-    FRunnableThread* Thread = nullptr;
+    TAtomic<FRunnableThread*> Thread = nullptr;
 
     /** An accumulator for error messages */
     TQueue<FRpcError> ErrorMessageQueue;


### PR DESCRIPTION
When a RPC client is destroyed by GC, which is always called when changing scenes, there could be an issue where its Conduits would be destroyed, and then FRunnableThread would try to access them, crashing the engine in process.
To mitigate this, BeginDestroy, which is called before destructor, would Stop the RPC client; also, FRunnableThread is stored via an Atomic; this fixes synchronization issues with multiple calls to Stop()